### PR TITLE
Add local Postgres docker-compose service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ A modular pipeline for collecting Hong Kong scam and nuisance phone numbers. The
 python -m pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
+
+## Docker Compose
+
+An example `docker-compose.yml` is provided to start both the API and a local Postgres database:
+
+```bash
+docker-compose up
+```
+
+The database is exposed on `localhost:5432` with the user, password and database name all set to `callshield`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3.9'
 services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: callshield
+      POSTGRES_PASSWORD: callshield
+      POSTGRES_DB: callshield
+    ports:
+      - "5432:5432"
+    volumes:
+      - dbdata:/var/lib/postgresql/data
   api:
     image: python:3.11
     working_dir: /code
@@ -8,3 +19,5 @@ services:
     command: bash -c "pip install -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8000"
     ports:
       - "8000:8000"
+volumes:
+  dbdata:


### PR DESCRIPTION
## Summary
- include Postgres database service and volume in `docker-compose.yml`
- document how to run Docker Compose with local Postgres

## Testing
- `python -m pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement fastapi==0.115.0)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6a1f5e4b08332a70b563adfdef158