### PR TITLE
Expand run_all script to orchestrate pipeline and API

### DIFF
--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
-set -e
-
-python -m app.etl.pipeline
+set -euo pipefail
+source .venv/bin/activate || true
+export $(grep -v '^#' .env | xargs)
+make db
+sleep 3
+make schema || true
+make all
+make api


### PR DESCRIPTION
## Summary
- Extend `scripts/run_all.sh` to activate virtualenv, load environment variables, spin up the database, run ETL and publisher, and launch the API

## Testing
- `bash -n scripts/run_all.sh`
- `./scripts/run_all.sh` *(fails: .venv/bin/activate: No such file or directory; docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2f77ce88332b9b466060ff7a4f7