### PR TITLE
Use environment variables for Postgres configuration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,17 +1,26 @@
-from pydantic import BaseSettings
+"""Application configuration settings."""
+
+from dotenv import load_dotenv
+import os
 
 
-class Settings(BaseSettings):
-    """Application configuration loaded from environment variables."""
+# Load environment variables from a .env file if present
+load_dotenv()
 
-    DB_PATH: str = "./app.db"
+# Database connection URL
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://callshield:callshield@localhost:5432/callshield",
+)
 
-    class Config:
-        env_file = ".env"
+# FastAPI host and port configuration
+API_HOST = os.getenv("API_HOST", "0.0.0.0")
+API_PORT = int(os.getenv("API_PORT", "8080"))
 
+# Directory for published artifacts
+PUBLISH_DIR = os.getenv("PUBLISH_DIR", "app/public")
 
-def get_settings() -> Settings:
-    return Settings()
+# Miscellaneous ETL settings
+IOS_CHUNK_SIZE = int(os.getenv("IOS_CHUNK_SIZE", "50000"))
+DELTA_MAX_LOOKBACK_DAYS = int(os.getenv("DELTA_MAX_LOOKBACK_DAYS", "7"))
 
-
-settings = get_settings()

--- a/app/db.py
+++ b/app/db.py
@@ -1,19 +1,24 @@
-import sqlite3
+"""Database connection helpers."""
+
 from contextlib import contextmanager
 
-from .config import settings
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from .config import DATABASE_URL
 
 
-def get_connection() -> sqlite3.Connection:
-    conn = sqlite3.connect(settings.DB_PATH)
-    conn.row_factory = sqlite3.Row
-    return conn
+def get_connection() -> psycopg2.extensions.connection:
+    """Create a new database connection using the configured URL."""
+    return psycopg2.connect(DATABASE_URL, cursor_factory=RealDictCursor)
 
 
 @contextmanager
 def get_db():
+    """Context manager yielding a database connection."""
     conn = get_connection()
     try:
         yield conn
     finally:
         conn.close()
+

--- a/app/etl/publisher.py
+++ b/app/etl/publisher.py
@@ -3,11 +3,14 @@
 from pathlib import Path
 import json
 
+from ..config import PUBLISH_DIR
 
-def publish(records: list[dict], output_dir: str = "app/public/snapshots") -> Path:
-    path = Path(output_dir)
-    path.mkdir(parents=True, exist_ok=True)
-    outfile = path / "latest.json"
+
+def publish(records: list[dict], output_dir: str | None = None) -> Path:
+    """Write records to a JSON file under the publish directory."""
+    base = Path(output_dir or PUBLISH_DIR) / "snapshots"
+    base.mkdir(parents=True, exist_ok=True)
+    outfile = base / "latest.json"
     with outfile.open("w", encoding="utf-8") as fh:
         json.dump(records, fh, ensure_ascii=False, indent=2)
     return outfile

--- a/app/routers/v1.py
+++ b/app/routers/v1.py
@@ -9,11 +9,12 @@ router = APIRouter()
 @router.get("/numbers/{phone}", response_model=PhoneRecord)
 def get_phone(phone: str) -> PhoneRecord:
     with get_db() as db:
-        cur = db.execute(
-            "SELECT number, source, score, created_at FROM phones WHERE number = ?",
-            (phone,),
-        )
-        row = cur.fetchone()
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT number, source, score, created_at FROM phones WHERE number = %s",
+                (phone,),
+            )
+            row = cur.fetchone()
     if row:
         return PhoneRecord(**row)
     raise HTTPException(status_code=404, detail="number not found")


### PR DESCRIPTION
## Summary
- load configuration via `dotenv` and environment variables
- connect to Postgres using `psycopg2` and update API query
- derive publisher output path from configured publish directory

## Testing
- `python -m py_compile app/config.py app/db.py app/routers/v1.py app/etl/publisher.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7b46fba248332a9b56ea3bc13351d