### PR TITLE
Add phone number E.164 normalization helper

### DIFF
--- a/app/utils/phone.py
+++ b/app/utils/phone.py
@@ -1,9 +1,25 @@
 """Utility functions for phone numbers."""
 
 import re
+import phonenumbers
 
+HK_REGION = "HK"
 NON_DIGITS = re.compile(r"\D")
 
 
 def normalize_phone(number: str) -> str:
     return NON_DIGITS.sub("", number)
+
+
+def to_e164(raw: str) -> tuple[str, bool] | None:
+    try:
+        num = phonenumbers.parse(raw, HK_REGION)
+        if not phonenumbers.is_valid_number(num):
+            return None
+        e164 = phonenumbers.format_number(
+            num, phonenumbers.PhoneNumberFormat.E164
+        )
+        is_overseas = num.country_code != 852
+        return e164, is_overseas
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- add `to_e164` helper to convert raw input into E.164 format and flag non-HK numbers

## Testing
- `python -m py_compile app/utils/phone.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7bf7a517883328ca88dd0f6986a9e