### PR TITLE
Use fixture data for ETL pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ app/public/snapshots/*
 !app/public/snapshots/.gitkeep
 app/public/delta/*
 !app/public/delta/.gitkeep
+app/public/ios/*
+!app/public/ios/.gitkeep
+app/public/latest.json

--- a/app/etl/normalizer.py
+++ b/app/etl/normalizer.py
@@ -1,10 +1,19 @@
 """Normalize source records."""
 
-from .sources import hkpf_scameter, hkma_alerts, sfc_alerts  # noqa: F401
 from ..utils.phone import normalize_phone
 
 
 def normalize(records: list[dict]) -> list[dict]:
+    """Ensure each record has an E.164 phone number.
+
+    The original sources may provide either a ``number`` field containing
+    arbitrary characters or an ``e164`` field.  For our test fixtures we only
+    supply ``e164`` so the normaliser simply preserves it, but if ``number`` is
+    provided we strip non-digit characters and prefix it with a ``+`` to
+    resemble an E.164 value.
+    """
+
     for rec in records:
-        rec["number"] = normalize_phone(rec["number"])
+        if "number" in rec and "e164" not in rec:
+            rec["e164"] = "+" + normalize_phone(rec["number"])
     return records

--- a/app/etl/pipeline.py
+++ b/app/etl/pipeline.py
@@ -1,17 +1,17 @@
 """Orchestrates the ETL workflow."""
 
+import asyncio
+
 from . import normalizer, scorer, publisher
-from .sources import hkpf_scameter, hkma_alerts, sfc_alerts
+from .sources._fixtures import fake_items
 
 
-def run() -> None:
-    records: list[dict] = []
-    for src in (hkpf_scameter, hkma_alerts, sfc_alerts):
-        records.extend(src.fetch())
+async def run() -> None:
+    records = fake_items()
     records = normalizer.normalize(records)
     records = scorer.score(records)
-    publisher.publish(records)
+    publisher.publish_delta(records)
 
 
 if __name__ == "__main__":
-    run()
+    asyncio.run(run())

--- a/app/etl/publisher.py
+++ b/app/etl/publisher.py
@@ -1,9 +1,12 @@
 """Publish processed records."""
 
-from pathlib import Path
-import json
+from __future__ import annotations
 
-from ..config import PUBLISH_DIR
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..config import IOS_CHUNK_SIZE, PUBLISH_DIR
 
 
 def publish(records: list[dict], output_dir: str | None = None) -> Path:
@@ -14,3 +17,45 @@ def publish(records: list[dict], output_dir: str | None = None) -> Path:
     with outfile.open("w", encoding="utf-8") as fh:
         json.dump(records, fh, ensure_ascii=False, indent=2)
     return outfile
+
+
+def publish_delta(records: list[dict], output_dir: str | None = None) -> Path:
+    """Write delta and iOS blocklist artifacts.
+
+    This simplified implementation treats all provided records as additions and
+    emits chunked blocklists for iOS clients as well as a ``latest.json`` index
+    file describing the generated artefacts.
+    """
+
+    base = Path(output_dir or PUBLISH_DIR)
+    delta_dir = base / "delta"
+    ios_dir = base / "ios"
+    delta_dir.mkdir(parents=True, exist_ok=True)
+    ios_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    additions = delta_dir / f"additions_{ts}.json"
+    removals = delta_dir / f"removals_{ts}.json"
+    with additions.open("w", encoding="utf-8") as fh:
+        json.dump(records, fh, ensure_ascii=False, indent=2)
+    with removals.open("w", encoding="utf-8") as fh:
+        json.dump([], fh, ensure_ascii=False, indent=2)
+
+    chunk_paths: list[str] = []
+    for i in range(0, len(records), IOS_CHUNK_SIZE):
+        chunk = records[i : i + IOS_CHUNK_SIZE]
+        outfile = ios_dir / f"blocklist_chunk_{(i // IOS_CHUNK_SIZE) + 1}.json"
+        with outfile.open("w", encoding="utf-8") as fh:
+            json.dump([r["e164"] for r in chunk], fh, ensure_ascii=False, indent=2)
+        chunk_paths.append(str(outfile.relative_to(base)))
+
+    latest = {
+        "generated_at": ts,
+        "additions": [str(additions.relative_to(base))],
+        "removals": [str(removals.relative_to(base))],
+        "ios_chunks": chunk_paths,
+    }
+    latest_path = base / "latest.json"
+    with latest_path.open("w", encoding="utf-8") as fh:
+        json.dump(latest, fh, ensure_ascii=False, indent=2)
+    return latest_path

--- a/app/etl/sources/_fixtures.py
+++ b/app/etl/sources/_fixtures.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def fake_items() -> list[dict]:
+    return [
+        {"e164": "+85261234567", "label": "scam", "snippet": "測試號碼 A", "url": "https://example/a", "source": "HKPF"},
+        {"e164": "+85251234567", "label": "telemarketing", "snippet": "測試號碼 B", "url": "https://example/b", "source": "HKMA"},
+        {"e164": "+81312345678", "label": "scam", "snippet": "日本號測試", "url": "https://example/c", "source": "SFC"},
+    ]


### PR DESCRIPTION
## Summary
- Add fixture module with sample records for testing
- Normalize and score records before publishing delta and iOS blocklist outputs
- Extend publisher to emit delta/ios artifacts and ignore generated files

## Testing
- `make etl`
- `jq length app/public/delta/additions_*.json`
- `jq '.ios_chunks' app/public/latest.json`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7092dd08332a7de494155752227